### PR TITLE
[WIP]データベース設計の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ### Association
 - has_many :messages
-- belongs_to :user, through: :user_group
+- has_many :users, through: :user_group
 - belongs_to :user_group
 
 ## users_groupsテーブル

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false|
-|email|text|null: false|
+|name|string|null: false|
+|email|string|index: true, unique: true null: false|
 
 ### Association
 - has_many :groups ,through: :users_groups

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 |name|text|null: false|
 |email|text|null: false|
 
-###Association
+### Association
 - has_many :groups ,through: :users_groups
 - has_many :messages
 
-##messagesテーブル
+## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |body|text|null: false|
@@ -17,26 +17,26 @@
 |group_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
 
-###Association
+### Association
 - belongs_to :users
 - belongs_to :groups
 
-##groupsテーブル
+## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |messages_id|integer|null: false, foreign_key: true|
 |users_id|integer|null: false, foreign_key: true|
 
-###Association
+### Association
 - has_many :messages
 - belongs_to :users ,through: :users_groups
 
-##users_groupsテーブル
+## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |users_id|integer|null: false, foreign_key: true|
 |groups_id|integer|null: false, foreign_key: true|
 
-###Association
+### Association
 - belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 |email|string|index: true, unique: true null: false|
 
 ### Association
-- has_many :groups ,through: :users_groups
+- has_many :groups, through: :users_groups
 - has_many :messages
+- has_many :users_groups
 
 ## messagesテーブル
 |Column|Type|Options|
@@ -18,8 +19,8 @@
 |user_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :users
-- belongs_to :groups
+- belongs_to :user
+- belongs_to :group
 
 ## groupsテーブル
 |Column|Type|Options|
@@ -29,7 +30,8 @@
 
 ### Association
 - has_many :messages
-- belongs_to :users ,through: :users_groups
+- belongs_to :user, through: :user_group
+- belongs_to :user_group
 
 ## users_groupsテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # chat-space
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|text|null: false|
+|email|text|null: false|
+
+###Association
+- has_many :groups ,through: :users_groups
+- has_many :messages
+
+##messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|mediumblog||
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+###Association
+- belongs_to :users
+- belongs_to :groups
+
+##groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|messages_id|integer|null: false, foreign_key: true|
+|users_id|integer|null: false, foreign_key: true|
+
+###Association
+- has_many :messages
+- belongs_to :users ,through: :users_groups
+
+##users_groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|users_id|integer|null: false, foreign_key: true|
+|groups_id|integer|null: false, foreign_key: true|
+
+###Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
 # What
usersテーブルのAssociationに- has_many :users_groups を追加
groupsテーブルのAssociationに- belongs_to :user_group を追加
belongs_to の後の複数形を単数形に変更

#Why
usersテーブルとusers_groupsテーブルのリレーションがなかったため
groupsテーブルとusers_groupsテーブルのリレーションがなかったため
belongs_toの後は単数形のため


