### PR TITLE
データベース設計の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 |email|string|index: true, unique: true null: false|
 
 ### Association
-- has_many :groups, through: :users_groups
+- has_many :groups, through: :members
 - has_many :messages
-- has_many :users_groups
+- has_many :members
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |body|text||
 |image|string||
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
@@ -29,14 +29,14 @@
 
 ### Association
 - has_many :messages
-- has_many :users, through: :user_groups
-- has_many :users_groups
+- has_many :users, through: :members
+- has_many :members
 
-## users_groupsテーブル
+## membersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|users_id|integer|null: false, foreign_key: true|
-|groups_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group


### PR DESCRIPTION
# what
users_groupsテーブルをmembersテーブルに変更
それに従い、それぞれのAssociationの users_groups を members に変更
membersテーブルのカラム名を group_id と user_id に変更
membersテーブルと、messagesテーブルのカラムの型を全て references に変更

# why
意味を持たせたテーブル名の方がわかりやすいため
references型出ないと外部キー制約がつかないため